### PR TITLE
Update graphql-remote_loader to 1.0.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'sqlite3'
 gem 'puma', '~> 3.11'
 gem 'bootsnap'
 
-gem 'graphql-remote_loader', '~> 1.0.0'
+gem 'graphql-remote_loader', '~> 1.0.4'
 gem 'graphql-client'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,13 +57,13 @@ GEM
       railties
       sprockets-rails
     graphql (1.8.2)
-    graphql-batch (0.3.9)
+    graphql-batch (0.3.10)
       graphql (>= 0.8, < 2)
       promise.rb (~> 0.7.2)
     graphql-client (0.12.3)
       activesupport (>= 3.0, < 6.0)
       graphql (~> 1.6)
-    graphql-remote_loader (1.0.0)
+    graphql-remote_loader (1.0.4)
       graphql (~> 1.6)
       graphql-batch (~> 0.3)
     i18n (1.0.1)
@@ -151,7 +151,7 @@ DEPENDENCIES
   byebug
   graphiql-rails
   graphql-client
-  graphql-remote_loader (~> 1.0.0)
+  graphql-remote_loader (~> 1.0.4)
   listen (>= 3.0.5, < 3.2)
   puma (~> 3.11)
   rails (~> 5.2.0)

--- a/app/graphql/loaders/github_loader.rb
+++ b/app/graphql/loaders/github_loader.rb
@@ -13,7 +13,7 @@ require "graphql/remote_loader"
 # This loader uses GraphQL::Client to query the remote API.
 # GitHubClient is defined in config/application.rb
 class GitHubLoader < GraphQL::RemoteLoader::Loader
-  def query(query_string)
+  def query(query_string, context: {})
     parsed_query = GitHubClient.parse(query_string)
     GitHubClient.query(parsed_query, variables: {}, context: {})
   end


### PR DESCRIPTION
Closes #1 

Updates the gem to 1.0.4